### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/joeip0411/16e0b606-e15d-43cd-9ed0-02af5ec0b228/dea8a35c-95a9-43e9-8556-05333be47136/_apis/work/boardbadge/37a4c422-c18b-491d-af13-504ca930b304)](https://dev.azure.com/joeip0411/16e0b606-e15d-43cd-9ed0-02af5ec0b228/_boards/board/t/dea8a35c-95a9-43e9-8556-05333be47136/Microsoft.RequirementCategory)
 # GroceryAnalytics
 Data engineering pipeline for grocery prices


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/joeip0411/16e0b606-e15d-43cd-9ed0-02af5ec0b228/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.